### PR TITLE
Change default_outgoing arg to Option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-actor-expect"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 edition = "2018"
 authors = ["Ana Bujan <ana@eisberg-labs.com>"]
 readme = "README.md"


### PR DESCRIPTION
- Removed mandatory `Debug` for incoming and outgoing. Only usage was in reporting `Cannot downcast command!`, which always writes `Any{..}`
- Change default_outgoing arg to Option.